### PR TITLE
Fix parsing of nosetest results

### DIFF
--- a/polytester/parsers/nose.py
+++ b/polytester/parsers/nose.py
@@ -7,7 +7,7 @@ class NoseParser(DefaultParser):
     name = "nose"
 
     def command_matches(self, command):
-        return "nosetests" in command
+        return "nosetests" in command or '-m nose' in command
 
     def num_passed(self, result):
         return self.num_total(result) - self.num_failed(result)

--- a/polytester/parsers/nose.py
+++ b/polytester/parsers/nose.py
@@ -15,18 +15,24 @@ class NoseParser(DefaultParser):
     def num_total(self, result):
         # Ran 2 test(s) in nnn seconds.
         m = re.findall('Ran (\d+) tests?', result.output)
-        return int(m[-1][0])
-    
+        return int(m[-1])
+
     def num_failed(self, result):
         # If failed, you'll see one of
         # FAILED (failures=1)
         # FAILED (failures=1, errors=1)
-        # FAILED (errors=1)
-        m = re.findall('FAILED \(failures=(\d+)', result.output)
+        failed = 0
+        m = re.findall('FAILED \(.*failures=(\d+)', result.output)
         if len(m) > 0:
-            return int(m[-1][0])
-        else:
-            m = re.findall('FAILED \(errors=(\d+)', result.output)
-            if len(m) > 0:
-                return int(m[-1][0])
-            return 0
+            failed += int(m[-1])
+        failed += self.num_error(result)
+        return failed
+
+    def num_error(self, result):
+        # If errored, you'll see one of
+        # FAILED (failures=1, errors=1)
+        # FAILED (errors=1)
+        m = re.findall('FAILED \(.*errors=(\d+)', result.output)
+        if len(m) > 0:
+            return int(m[-1])
+        return 0


### PR DESCRIPTION
The nose parser uses the first character of the parsed strings, causing the test failure/pass counts to always be wrong when there are more than a single digit number of tests/failures/errors.

Try it out:

```python
# test_nose_parser.py
from nose.tools import assert_true

def tests_should_pass():
    for i in xrange(10):
        yield assert_true, type(i) == int

def tests_should_fail():
    for i in xrange(10):
        yield assert_true, type(i) == str

def test_should_error():
    import foo
```