### PR TITLE
Add support for built in python unittest library

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ In addition, polytester progressively upgrades to extra-nice output for the fram
 - [Protractor](http://angular.github.io/protractor/)
 - [Python Nose](https://nose.readthedocs.org/en/latest/)
 - [Python py.test](http://pytest.org/latest/)
+- [Python unittest](https://docs.python.org/3/library/unittest.html)
 - [Salad](https://github.com/salad/salad)
 
 But again, for extra clarity - if your test runner returns normal output codes, you can just drop it in and it'll work great.

--- a/polytester/parsers/__init__.py
+++ b/polytester/parsers/__init__.py
@@ -6,3 +6,4 @@ from .nose import NoseParser
 from .protractor import ProtractorParser
 from .salad import SaladParser
 from .pytest import PyTestParser
+from .unittest import UnittestParser

--- a/polytester/parsers/unittest.py
+++ b/polytester/parsers/unittest.py
@@ -1,0 +1,9 @@
+from .nose import NoseParser
+
+
+class UnittestParser(NoseParser):
+    """Output when using `python -m unittest` is the same as nose output."""
+    name = "unittest"
+
+    def command_matches(self, command):
+        return "unittest" in command

--- a/polytester/runner.py
+++ b/polytester/runner.py
@@ -28,6 +28,7 @@ BUNDLED_PARSERS = [
     KarmaParser, 
     NoseParser, 
     PyTestParser,
+    UnittestParser,
     ProtractorParser,
     SaladParser,
 ]


### PR DESCRIPTION
Essentially the exact same parser as for `nosetests`. I dunno why someone would use `python -m unittest` when things like `nose` and `py.test` exist, but hey, why not support it?