### PR TITLE
Switch to a different regular expression to escape ansi colors.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Steven Skoczen, BuddyUp, http://buddyup.org
 Josh Friend, MichiganLabs, http://michiganlabs.com
+Brandon Cazander, https://github.com/brandoncazander

--- a/polytester/runner.py
+++ b/polytester/runner.py
@@ -95,7 +95,7 @@ class PolytesterRunner(object):
         sys.exit(1)
 
     def strip_ansi_colors(self, string):
-        ansi_escape = re.compile(r'\\x1b([^m]*)?m')
+        ansi_escape = re.compile(r's/\x1b\[[0-9;]*m//g')
         return ansi_escape.sub('', repr(string))
 
     def __init__(self, arg_options):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+from polytester.main import parser
+from polytester.runner import PolytesterRunner
+
+
+class TestRunner(object):
+    def test_strip_ansi_colors(self):
+        """Verify that ansi color codes are stripped from strings."""
+        runner = PolytesterRunner(parser.parse_args([]))
+        colored_string = "\e[31mHello World\e[0m"
+        escaped = repr("\\e[31mHello World\\e[0m")
+        assert runner.strip_ansi_colors(colored_string) == escaped

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -7,7 +7,7 @@ from polytester.runner import PolytesterRunner
 class TestRunner(object):
     def test_strip_ansi_colors(self):
         """Verify that ansi color codes are stripped from strings."""
-        runner = PolytesterRunner(parser.parse_args([]))
+        runner = PolytesterRunner(parser.parse_args(['--config', 'tests/tests.yml']))
         colored_string = "\e[31mHello World\e[0m"
         escaped = repr("\\e[31mHello World\\e[0m")
         assert runner.strip_ansi_colors(colored_string) == escaped

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -1,0 +1,2 @@
+do_nothing:
+    command: python setup.py test


### PR DESCRIPTION
My regex-fu isn't very good, so I shamelessly stole the new regular expression from http://superuser.com/a/380778

Tested against python 2.6.9 (not working before) and 2.7.8 (working before).

Fixes #8.